### PR TITLE
GBD MultiArch

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To compile the firmware you will need `arm-none-eabi-gcc` compiler.
 
 On MacOS install it using brew: `brew install arm-none-eabi-gcc`
 
-On Linux: `sudo apt-get install gcc-arm-none-eabi binutils-arm-none-eabi gdb-arm-none-eabi openocd`
+On Linux: `sudo apt-get install gcc-arm-none-eabi binutils-arm-none-eabi gdb-multiarch openocd`
 
 We have a set of small shell scripts that compile micropython for discovery board or unix/mac. Feel free to check out content of these scripts and tune it if you want:
 


### PR DESCRIPTION
I couldn't install gdb-arm-none-eabi but gbd-multiarch worked no problem.
Might be worth considering testing & if it works substituting or adding as an option