### PR TITLE
ci: trigger release workflow on tag creation via UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,12 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  create:
 
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Add `create` event trigger so the release workflow runs when tags are created through GitHub's web interface, not just via git push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)