### PR TITLE
feat(scard): add T=1 USART reconfiguration after ATR for spec-compliant timing

### DIFF
--- a/usermods/scard/connection.c
+++ b/usermods/scard/connection.c
@@ -85,6 +85,7 @@ typedef struct connection_obj_ {
   int32_t rsp_timeout_ms;        ///< Response timeout in ms
   int32_t max_timeout_ms;        ///< Maximal response timeout in ms
   bool raise_on_error;           ///< Forces exception for non-blocking mode
+  bool t1_usart_configured;      ///< Flag: USART reconfigured for T=1 protocol
   event_t event_buf[MAX_EVENTS]; ///< Event buffer
   size_t event_idx;              ///< Event index within event_buf[]
   mp_obj_t atr;                  ///< ATR as bytes object
@@ -280,6 +281,13 @@ static mp_obj_t make_response_list(const uint8_t* data, size_t len) {
 static bool proto_cb_serial_out(mp_obj_t self_in, const uint8_t* buf,
                                 size_t len) {
   connection_obj_t* self = (connection_obj_t*)self_in;
+  // One-shot: reconfigure USART for T=1 before first T=1 block is sent
+  // (which is the IFSD request). This must happen after ATR reception
+  // (which needs 1.5 stop bits) but before IFSD send.
+  if(!self->t1_usart_configured && self->sc_handle) {
+    scard_configure_t1(self->sc_handle);
+    self->t1_usart_configured = true;
+  }
   return scard_tx_write(self->sc_handle, buf, len);
 }
 
@@ -520,6 +528,7 @@ static void connection_init(connection_obj_t* self,
 
   // Make connection alive
   self->state = state_disconnected;
+  self->t1_usart_configured = false;
 }
 
 /**

--- a/usermods/scard/ports/stm32/scard_io.c
+++ b/usermods/scard/ports/stm32/scard_io.c
@@ -364,6 +364,7 @@ bool scard_tx_write(scard_handle_t handle, const uint8_t* buf, size_t nbytes) {
   size_t bytes_written = uart_tx_data(handle->uart_obj, buf, nbytes, &errcode);
 
   return (errcode == 0 && bytes_written == nbytes);
+}
 
 /**
  * Reconfigures USART for T=1 protocol after ATR reception.

--- a/usermods/scard/ports/stm32/scard_io.c
+++ b/usermods/scard/ports/stm32/scard_io.c
@@ -364,8 +364,46 @@ bool scard_tx_write(scard_handle_t handle, const uint8_t* buf, size_t nbytes) {
   size_t bytes_written = uart_tx_data(handle->uart_obj, buf, nbytes, &errcode);
 
   return (errcode == 0 && bytes_written == nbytes);
-}
 
+/**
+ * Reconfigures USART for T=1 protocol after ATR reception.
+ * Switches stop bits from 1.5 to 1 and reduces guard time to 1 ETU.
+ * Must be called after ATR is received and before first T=1 block is sent.
+ * @param handle  smart card interface handle
+ */
+void scard_configure_t1(scard_handle_t handle) {
+#if defined(STM32F4)
+  USART_TypeDef* usart = handle->sc_handle.Instance;
+  uint32_t irq_state = disable_irq();
+  
+  // Disable USART before modifying registers
+  __HAL_SMARTCARD_DISABLE(&handle->sc_handle);
+  
+  // T=1: switch stop bits from 1.5 to 1.
+  // T=1 uses 1 ETU guard time (no NACK mechanism), vs T=0's 2 ETU.
+  // CR2 bits 13:12: 00 = 1 stop bit. HAL only defines 0.5/1.5 for smartcard,
+  // so we manipulate registers directly.
+  // See ccid-reader/src/smartcard.rs:524-529
+  usart->CR2 &= ~USART_CR2_STOP;  // Clear bits 13:12 -> 1 stop bit
+  
+  // T=1: reduce guard time from 16 to 1 ETU.
+  // GT=1 is minimum for T=1 (just the stop bit).
+  // GTPR[15:8] = GT value, GTPR[7:0] = PSC (prescaler, keep unchanged)
+  // See ccid-reader/src/smartcard.rs:530-534
+  uint32_t psc = usart->GTPR & 0xFFU;  // Preserve prescaler
+  usart->GTPR = (1U << 8) | psc;        // GT=1, keep PSC
+  
+  // Re-enable USART
+  __HAL_SMARTCARD_ENABLE(&handle->sc_handle);
+  
+  enable_irq(irq_state);
+  
+  if(scard_module_debug) {
+    printf("\r\nT=1: STOP=1bit, GT=1, CR2=0x%08lX, GTPR=0x%04lX",
+           (unsigned long)usart->CR2, (unsigned long)usart->GTPR);
+  }
+#endif // STM32F4
+}
 void scard_interface_deinit(scard_handle_t handle) {
   scard_inst_t* self = (scard_inst_t*)handle;
 

--- a/usermods/scard/ports/stm32/scard_io.h
+++ b/usermods/scard/ports/stm32/scard_io.h
@@ -53,5 +53,12 @@ static inline scard_pin_state_t scard_pin_read(scard_pin_dsc_t* p_pin) {
   uint32_t state = mp_hal_pin_read(p_pin->pin) ? 1U : 0U;
   return (scard_pin_state_t)(state ^ p_pin->invert);
 }
+/**
+ * Reconfigures USART for T=1 protocol after ATR reception.
+ * Switches stop bits from 1.5 to 1 and reduces guard time to 1 ETU.
+ * Must be called after ATR is received and before first T=1 block is sent.
+ * @param handle  smart card interface handle
+ */
+void scard_configure_t1(scard_handle_t handle);
 
 #endif // SCARD_IO_H_INCLUDED


### PR DESCRIPTION
# T=1 USART Reconfiguration After ATR

## What it does

ISO 7816-3 specifies different USART timing for T=0 and T=1:

| Parameter | T=0 (ATR default) | T=1 |
|-----------|-------------------|-----|
| Stop bits | 1.5 | 1 |
| Guard time | 2 ETU | 1 ETU |

This branch adds `scard_configure_t1()` called once after ATR, before the first T=1 block. It reconfigures:
- CR2.STOP: 11 → 00 (1.5 → 1 stop bit)
- GTPR[15:8]: 16 → 1 (guard time)

## Why consider it

- ISO 7816-3 spec-compliant T=1 timing
- ~1 ETU saved per character (~0.1ms at 9600 baud)
- Matches reference implementations (osmo-ccid-firmware)

## Why not merge

**The tradeoff doesn't justify the complexity:**

1. **T=0 timing works for all known T=1 cards** — giving cards *more* time is harmless
2. **Negligible practical gain** — ~0.1ms per character at typical smartcard speeds
3. **Added complexity** — new `t1_usart_configured` flag, state to track
4. **HAL bypass** — direct register manipulation is STM32F4-specific, fragile across families
5. **Bug surface** — if reconfiguration fails, T=1 breaks entirely

The "just works" approach (T=0 timing for T=1) is more robust than spec pedantry.


## References

- ISO 7816-3, Section 10 (T=0) and Section 12 (T=1)
- osmo-ccid-firmware: `sysmoOCTSIM/cuart_driver_asf4_usart_async.c`
- STM32 Reference Manual: USART CR2, GTPR
