### PR TITLE
Fix qrcode usermod: detect binary payloads by Python type, not content

### DIFF
--- a/usermods/qrcode/qrcode.c
+++ b/usermods/qrcode/qrcode.c
@@ -10,16 +10,21 @@ static bool _qrcode_encode(uint8_t * qrcode, mp_obj_t text_obj){
     mp_get_buffer_raise(text_obj, &bufinfo, MP_BUFFER_READ);
 
     enum qrcodegen_Ecc errCorLvl = qrcodegen_Ecc_LOW;  // Error correction level
-    
+
+    if(bufinfo.len > qrcodegen_BUFFER_LEN_MAX){
+        mp_raise_ValueError("Data is too long to encode");
+    }
+
     uint8_t tempBuffer[qrcodegen_BUFFER_LEN_MAX];
     memcpy(tempBuffer, bufinfo.buf, bufinfo.len);
     bool ok = false;
-    bool is_bytes = false;
-    for(int i = 0; i < bufinfo.len; i++){
-        if(tempBuffer[i] == 0){ // \x00 will cut the byte array
-            is_bytes = true;
-        }
-    }
+    // Binary mode is required for arbitrary bytes payloads (e.g. Compact SeedQR
+    // raw entropy): a bytes object may legitimately contain no 0x00 byte at all,
+    // so sniffing for an embedded NUL to detect "binary" data is unreliable and
+    // can make qrcodegen_encodeText() (which expects a NUL-terminated C string)
+    // read past the intended payload into uninitialized stack memory. The
+    // object's actual Python type tells us unambiguously what the caller meant.
+    bool is_bytes = mp_obj_is_type(text_obj, &mp_type_bytes);
     if(is_bytes){
         ok = qrcodegen_encodeBinary(tempBuffer, bufinfo.len, qrcode, errCorLvl,
             qrcodegen_VERSION_MIN, qrcodegen_VERSION_MAX, qrcodegen_Mask_AUTO, true);


### PR DESCRIPTION
## Summary
`_qrcode_encode()` in `usermods/qrcode/qrcode.c` decided whether to call
`qrcodegen_encodeText()` or `qrcodegen_encodeBinary()` by scanning the
input buffer for an embedded `0x00` byte. A `bytes` payload that happens to
contain no zero byte at all (very common for e.g. 16/32-byte random
entropy — roughly 88–94% of the time) falls through to
`qrcodegen_encodeText()`, which expects a NUL-terminated C string and can
read past the intended payload into uninitialized stack memory.

This surfaced while building a SeedQR (BIP-39 compact/binary QR) feature on
top of this usermod: Compact SeedQR payloads are raw entropy bytes with no
particular structure, so the existing heuristic silently produced wrong
(and potentially privacy-sensitive, stack-garbage-containing) QR codes most
of the time.

## Fix
Use the actual Python object type (`bytes` vs. `str`) via
`mp_obj_is_type(text_obj, &mp_type_bytes)` instead of content-sniffing —
this is what every existing caller in the tree already relies on
semantically (`bytes` → binary, `str` → text), and it's unambiguous no
matter what bytes happen to be present.

Also added a bounds check on the `memcpy` into the fixed-size
`tempBuffer`, since the existing code had no length check that
`bufinfo.len` fits within `qrcodegen_BUFFER_LEN_MAX`.

## Test plan
- [x] Verified against the compiled unix port (`make unix`): the fixed
      `qrcode.encode_to_string()` produces the correct QR module-matrix size
      for both digit-string and raw-bytes payloads, including entropy with
      no embedded zero byte (the exact case the old heuristic mishandled).
- [ ] No automated C-level unit tests exist in this repo for this usermod;
      happy to add one if there's a preferred harness.